### PR TITLE
Fix build by including <array>

### DIFF
--- a/lib/cyclonev.h
+++ b/lib/cyclonev.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <cassert>
 #include <memory>
+#include <array>
 
 namespace mistral {
   class CycloneV {


### PR DESCRIPTION
Trivial fix that allows compilation of mistral-cv. Tested on mac os.