### PR TITLE
Initial changes for nextpnr support

### DIFF
--- a/lib/cv-rmux.cc
+++ b/lib/cv-rmux.cc
@@ -30,11 +30,11 @@ std::string mistral::CycloneV::pn2s(pnode_t pn)
 }
 
 
-void mistral::CycloneV::rmux_load()
+void mistral::CycloneV::rmux_load(const std::string &mistral_root)
 {
   char path[2048];
   char msg[4096];
-  sprintf(path, "../gdata/%s-r.bin", di.name);
+  sprintf(path, "%s/gdata/%s-r.bin", mistral_root.c_str(), di.name);
   sprintf(msg, "Error opening %s for reading", path);
   FILE *fd = fopen(path, "rb");
   if(!fd) {

--- a/lib/cyclonev.cc
+++ b/lib/cyclonev.cc
@@ -16,14 +16,14 @@ const mistral::CycloneV::package_info_t mistral::CycloneV::package_infos[5+3+3] 
     {  484, 'm', 28, 28, 15, 15 },
 };
 
-mistral::CycloneV *mistral::CycloneV::get_model(std::string model_name)
+mistral::CycloneV *mistral::CycloneV::get_model(std::string model_name, std::string mistral_root)
 {
   if(model_name == "ms")
     model_name = "5CSEBA6U23I7";
 
   for(const Model *m = models; m->name; m++)
     if(model_name == m->name)
-      return new CycloneV(m);
+      return new CycloneV(m, mistral_root);
   return nullptr;
 }
 
@@ -115,9 +115,9 @@ const mistral::CycloneV::block_type_t mistral::CycloneV::hps_index_to_type[I_HPS
   HPS_TPIU_TRACE,
 };
 
-mistral::CycloneV::CycloneV(const Model *m) : model(m), di(m->variant.die)
+mistral::CycloneV::CycloneV(const Model *m, const std::string &mistral_root) : model(m), di(m->variant.die)
 {
-  rmux_load();
+  rmux_load(mistral_root);
 
   any_type_hash_init(rnode_type_hash, rnode_type_names);
   any_type_hash_init(block_type_hash, block_type_names);

--- a/lib/cyclonev.h
+++ b/lib/cyclonev.h
@@ -413,6 +413,16 @@ namespace mistral {
     
     static const Model models[];
     static CycloneV *get_model(std::string model_name);
+
+    struct rmux {
+      rnode_t destination;
+      uint32_t pattern;
+      uint32_t fw_pos;
+      rnode_t sources[44];
+    };
+
+    std::unique_ptr<rmux []> rmux_info;
+    std::unordered_map<rnode_t, uint32_t> dest_node_to_rmux;
     
   private:
     enum bmux_ram_t { BM_CRAM, BM_PRAM, BM_ORAM, BM_DCRAM };
@@ -427,13 +437,6 @@ namespace mistral {
       uint16_t o_xy;
       uint16_t o_vals;
       uint16_t o_vhash;
-    };
-
-    struct rmux {
-      rnode_t destination;
-      uint32_t pattern;
-      uint32_t fw_pos;
-      rnode_t sources[44];
     };
 
     struct bmux_sel_entry {
@@ -684,9 +687,6 @@ namespace mistral {
     std::vector<pos_t> term_pos;
     std::vector<pos_t> hip_pos;
     std::vector<pos_t> hmc_pos;
-    
-    std::unique_ptr<rmux []> rmux_info;
-    std::unordered_map<rnode_t, uint32_t> dest_node_to_rmux;
 
     std::unordered_map<pnode_t, rnode_t> p2r_map;
     std::unordered_map<rnode_t, pnode_t> r2p_map;

--- a/lib/cyclonev.h
+++ b/lib/cyclonev.h
@@ -207,7 +207,7 @@ namespace mistral {
 
     struct Model;
 
-    CycloneV(const Model *m);
+    CycloneV(const Model *m, const std::string &mistral_root = "..");
     ~CycloneV() = default;
 
     // Chosen model
@@ -412,7 +412,7 @@ namespace mistral {
     static const variant_info v_se120b, v_se120bs, v_se120m, v_se90b, v_se90bs, v_se90m, v_st120f, v_st90f, v_sx120f, v_sx90f;
     
     static const Model models[];
-    static CycloneV *get_model(std::string model_name);
+    static CycloneV *get_model(std::string model_name, std::string mistral_root = "..");
 
     struct rmux {
       rnode_t destination;
@@ -693,7 +693,7 @@ namespace mistral {
 
     void rbf_load_oram(const void *data, uint32_t size);
 
-    void rmux_load();
+    void rmux_load(const std::string &mistral_root);
     void add_cram_blocks();
     void add_pram_blocks();
     void add_pram_fixed(std::vector<pos_t> &pos, block_type_t block, int start, int count);


### PR DESCRIPTION
 - Allow loading routing data from a specified path (until we come up with a better approach this will be a command line argument to nextpnr)
 - Make the routing data accessible to nextpnr. If you have suggestions for a better way of exposing it than just making the relevant fields public, I'm happy to hear them.