### PR TITLE
Let cmake find python3

### DIFF
--- a/libmistral/CMakeLists.txt
+++ b/libmistral/CMakeLists.txt
@@ -14,6 +14,8 @@ list(APPEND mistral_SOURCES
 set(TOOLS ${CMAKE_CURRENT_SOURCE_DIR}/../tools)
 set(DATA ${CMAKE_CURRENT_SOURCE_DIR}/../data)
 
+find_package(PythonInterp 3.5 REQUIRED)
+
 # C++ source generation/inclusion
 foreach(die e50f gx25f gt75f gt150f gt300f sx50f sx120f)
 
@@ -26,7 +28,7 @@ foreach(die e50f gx25f gt75f gt150f gt300f sx50f sx120f)
 
     add_custom_command(
        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-blk.cc
-       COMMAND python3 ${TOOLS}/blocks_to_source.py ${DATA} ${die} > ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-blk.cc
+       COMMAND ${PYTHON_EXECUTABLE} ${TOOLS}/blocks_to_source.py ${DATA} ${die} > ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-blk.cc
        DEPENDS ${TOOLS}/blocks_to_source.py ${DATA}/${die}-pram.txt ${DATA}/pma3-cram.txt ${DATA}/${die}-1.txt ${DATA}/${die}-iob.txt ${DATA}/${die}-hmc.txt ${DATA}/${die}-fpll.txt ${DATA}/${die}-ctrl.txt ${DATA}/${die}-dll.txt ${DATA}/${die}-cmux.txt ${DATA}/${die}-hps.txt
     )
     list(APPEND mistral_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-blk.cc)
@@ -36,7 +38,7 @@ foreach(die e50f gx25f gt75f gt150f gt300f sx50f sx120f)
 
     add_custom_command(
        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-pkg.cc
-       COMMAND python3 ${TOOLS}/pkg_to_source.py ${DATA} ${die} > ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-pkg.cc
+       COMMAND ${PYTHON_EXECUTABLE} ${TOOLS}/pkg_to_source.py ${DATA} ${die} > ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-pkg.cc
        DEPENDS ${TOOLS}/pkg_to_source.py ${DATA}/${die}-pkg.txt
     )
     list(APPEND mistral_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-pkg.cc)
@@ -46,7 +48,7 @@ foreach(die e50f gx25f gt75f gt150f gt300f sx50f sx120f)
 
     add_custom_command(
        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-inv.cc
-       COMMAND python3 ${TOOLS}/inv_to_source.py ${DATA} ${die} > ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-inv.cc
+       COMMAND ${PYTHON_EXECUTABLE} ${TOOLS}/inv_to_source.py ${DATA} ${die} > ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-inv.cc
        DEPENDS ${TOOLS}/inv_to_source.py ${DATA}/${die}-inv.txt
     )
     list(APPEND mistral_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/cvd-${die}-inv.cc)
@@ -59,7 +61,7 @@ endforeach()
 foreach(die e50f gx25f gt75f gt150f gt300f sx50f sx120f)
     add_custom_command(
        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${die}-r.bin
-       COMMAND ${TOOLS}/routes-to-bin.py ${DATA} ${CMAKE_CURRENT_SOURCE_DIR}/cv-rnodetypes.ipp ${die} ${CMAKE_CURRENT_BINARY_DIR}
+       COMMAND ${PYTHON_EXECUTABLE} ${TOOLS}/routes-to-bin.py ${DATA} ${CMAKE_CURRENT_SOURCE_DIR}/cv-rnodetypes.ipp ${die} ${CMAKE_CURRENT_BINARY_DIR}
        DEPENDS ${TOOLS}/routes-to-bin.py ${DATA}/${die}-r.txt.xz
     )
 


### PR DESCRIPTION
This would be proper way to do it, also last command was totally missing explicit setting of python interpreter so was using python2 on some environments, due to path in top of script itself.