### PR TITLE
Fix some issues affecting the nextpnr build

### DIFF
--- a/libmistral/cyclonev.cc
+++ b/libmistral/cyclonev.cc
@@ -319,7 +319,7 @@ void mistral::CycloneV::add_cram_blocks()
 
     for(uint8_t x = xs; x <= xe; x++) {
       const uint8_t *spans = spans_start;
-      std::vector<uint16_t> *posvec;
+      std::vector<uint16_t> *posvec = nullptr;
       bool is_dsp = false;
       tile_type_t tp = di.column_types[x];
       switch(tp) {

--- a/libmistral/mistral-analogsim.h
+++ b/libmistral/mistral-analogsim.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <string>
 #include <memory>
+#include <array>
 
 namespace mistral {
   class AnalogSim {


### PR DESCRIPTION
A missing `<array>` include was causing a problem where it wasn't transitively included in my particular environment. Also add a default initialiser to suppress a compile warning (and make the pointer clearly null rather than some random value to make debugging a missed case or something easier in the future)